### PR TITLE
[Fix] null pointer dereference on the reused of destroyed entity.

### DIFF
--- a/pixbench/entity.cpp
+++ b/pixbench/entity.cpp
@@ -51,6 +51,7 @@ EntityID EntityManager::createEntity() {
     new_id.id = new_id_index;
     new_id.version = this->m_entities[new_id.id].current_version;
     this->m_entities[new_id.id].active = true;
+    this->m_entities[new_id.id].entityid.version = this->m_entities[new_id.id].current_version;
     this->m_uninitialized_entities.push_back(new_id);
     return new_id;
 }


### PR DESCRIPTION
## Description
When a new entity used id (index) of destroyed entity, it's version hadn't been update, resulting in `getComponent` function returning `nullptr`.

-------------
## Checklist:

1. [x] Was compilation (with `meson compile -C build/` and test run (with `build/game`) successful?
2. [x] Have you run the test with `meson test -C build`?
3. [x] Have you added code documentation and generate the docs with doxygen?
