### PR TITLE
[Dev] Tied camera scale with scene. And tied camera to screen.

### DIFF
--- a/include/pixbench/renderer.h
+++ b/include/pixbench/renderer.h
@@ -12,16 +12,19 @@
 #include <unordered_map>
 #include <vector>
 
+
 class RenderContext {
 public:
-    SDL_Renderer* renderer;
-    SDL_Window* window;
-    Vector2 camera_position;
-    Vector2 camera_size;
-    Color renderClearColor;
+    SDL_Renderer* renderer;     //!< SDL_Renderer
+    SDL_Window* window;         //!< SDL_Window
+    Vector2 camera_position;    //!< camera coordinate position in scene space
+    Vector2 camera_size;        //!< camera size in scene space
+    Vector2 screen_size;        //!< screen size in pixels
+    Color renderClearColor;     //!< Color of clear window
 
     RenderContext(
             std::string game_title,
+            Vector2 screen_size,
             Vector2 camera_position, Vector2 camera_size,
             Color render_clear_color
             )
@@ -29,8 +32,8 @@ public:
     {
         if (!SDL_CreateWindowAndRenderer(
                     game_title.c_str(),
-                    (int)camera_size.x,
-                    (int)camera_size.y,
+                    (int)screen_size.x,
+                    (int)screen_size.y,
                     SDL_WINDOW_RESIZABLE,
                     /*&new_window, &new_renderer*/
                     &(this->window), &(this->renderer)
@@ -39,6 +42,7 @@ public:
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Can't initialized SDL: %s", SDL_GetError());
             /*return 3;*/
         }
+        this->SetScreenSize(screen_size);
         this->SetCameraContext(camera_position, camera_size);
     }
 
@@ -47,12 +51,40 @@ public:
         SDL_DestroyWindow(this->window);
     }
 
+    void SetScreenSize(Vector2 screen_size) {
+        this->screen_size = screen_size;
+    }
+
     void SetCameraContext(Vector2 camera_position, Vector2 camera_size) {
         std::cout << "SetCameraContext called." << std::endl;
         this->camera_position = camera_position;
         this->camera_size = camera_size;
     }
 };
+
+
+SDL_FRect sceneToCamSpace(
+        RenderContext* renderContext,
+        SDL_FRect rect
+        );
+
+
+Vector2 sceneToCamSpace(
+        RenderContext* renderContext,
+        Vector2 point
+        );
+
+
+SDL_FRect camToScreenSpace(
+        RenderContext* renderContext,
+        SDL_FRect rect
+        );
+
+
+Vector2 camToScreenSpace(
+        RenderContext* renderContext,
+        Vector2 point
+        );
 
 
 /* Sprite Sheet */

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ engine_sources = [
   'pixbench/components.cpp',
   'pixbench/entity.cpp',
   'pixbench/systems.cpp',
+  'pixbench/rendering.cpp',
   ]
 
 sources = []

--- a/pixbench/game.cpp
+++ b/pixbench/game.cpp
@@ -120,6 +120,7 @@ Result<VoidResult, GameError> Game::PrepareRenderer(int windowWidth, int windowH
     }
     this->renderContext = new RenderContext(
             this->gameConfig.game_title.c_str(),
+            Vector2(windowWidth, windowHeight),
             Vector2(0.0, 0.0),
             Vector2(windowWidth, windowHeight),
             this->gameConfig.render_clear_color


### PR DESCRIPTION
## Description
Scaling towards the screen size should now only be done with `renderContext->camera_size`. Camera will be tied with screen, meaning it will be wrap to fit the screen. So zoom effect can be done by lowering the `game->renderContext->camera_size`.

In the future, the engine will by default render to a texture, and scaling camera render with the screen can happen in separate process than with entity rendering.

-------------
## Checklist:

1. [x] Was compilation (with `meson compile -C build/` and test run (with `build/game`) successful?
2. [x] Have you run the test with `meson test -C build`?
3. [ ] Have you added code documentation and generate the docs with doxygen?
