### PR TITLE
[Dev] Add animation speed multiplier and indication of finished animation to Sprite component.

### DIFF
--- a/include/pixbench/ecs.h
+++ b/include/pixbench/ecs.h
@@ -116,17 +116,19 @@ public:
 
 class Sprite : public RenderableComponent {
 private:
+    int m_max_frame = 0;
     std::shared_ptr<SpriteAnimation> sprite_anim = nullptr;
 public:
-    int max_frame = 0;
     int current_frame = 0;
     double current_anim_time_s = 0;
 
-    SDL_FlipMode flip_mode = SDL_FlipMode::SDL_FLIP_NONE;  // flip mode for the renderables
-    Vector2 offset;                                        // offset for rendering Sprite relative to transform
-    std::shared_ptr<Res_SDL_Texture> texture = nullptr;    // texture to render
+    double animation_speed_multiplier = 1;                  //!< animation speed multiplier (multiplied on top of SpriteAnimation' speed)
+    SDL_FlipMode flip_mode = SDL_FlipMode::SDL_FLIP_NONE;   //!< flip mode for the renderables
+    Vector2 offset;                                         //!< offset for rendering Sprite relative to transform
+    std::shared_ptr<Res_SDL_Texture> texture = nullptr;     //!< texture to render
 
     bool paused = false;
+    bool is_animation_finished = false;
 
     RenderableTag getRenderableTag() const override {
         return RCTAG_Sprite;
@@ -138,13 +140,22 @@ public:
             ) {
         this->sprite_anim = sprite_anim;
         this->texture = sprite_anim->res_sheet->res_texture;
+        this->m_max_frame = 1 + sprite_anim->end_sheet_index - sprite_anim->start_sheet_index;
         if (reset_anim)
             this->ResetAnimation();
     };
 
+    int maxFrame() {
+        return m_max_frame;
+    }
+
     void ResetAnimation() {
         this->current_frame = 0;
         this->current_anim_time_s = 0;
+    }
+
+    bool isAnimationFinished() {
+        return is_animation_finished;
     }
 
     void SetTexture(

--- a/pixbench/systems.cpp
+++ b/pixbench/systems.cpp
@@ -220,20 +220,26 @@ Result<VoidResult, GameError> RenderingSystem::LateUpdate(double delta_time_s, E
                     continue;
                 }
 
+                sprite->is_animation_finished = false;
+
                 sprite->current_anim_time_s += delta_time_s;
-                int elapsed_frames = std::floor(sprite->current_anim_time_s * (double)sprite_anim->animation_speed);
-                double time_residue = std::fmod(sprite->current_anim_time_s, 1.0/(double)sprite_anim->animation_speed);
+                const double animation_speed = (double)sprite_anim->animation_speed * sprite->animation_speed_multiplier;
+                const int elapsed_frames = std::floor(sprite->current_anim_time_s * animation_speed);
+                const double time_residue = std::fmod(sprite->current_anim_time_s, 1.0/animation_speed);
                 sprite->current_anim_time_s = time_residue;
                 sprite->current_frame += elapsed_frames;
 
-                const int frame_counts = 1 + sprite_anim->end_sheet_index - sprite_anim->start_sheet_index;
+                const int max_frame = sprite->maxFrame();
+                if (sprite->current_frame >= max_frame) {
+                    sprite->is_animation_finished = true;
+                }
                 if (sprite_anim->repeat) {
                     sprite->current_frame = std::fmod(
                             sprite->current_frame,
-                            frame_counts
+                            max_frame
                             );
                 } else {
-                    sprite->current_frame = std::min(sprite->current_frame, frame_counts-1);
+                    sprite->current_frame = std::min(sprite->current_frame, max_frame-1);
                 }
 
                 sprite->srect = sprite_anim->res_sheet->GetRectByFrameIndex(sprite->current_frame);


### PR DESCRIPTION
## Description
Add animation speed multiplier and indication of finished animation to Sprite component.

-------------
## Checklist:

1. [x] Was compilation (with `meson compile -C build/` and test run (with `build/game`) successful?
2. [x] Have you run the test with `meson test -C build`?
