### PR TITLE
[Temporary Fix] Anchoring version of SDL_mixer

### DIFF
--- a/subprojects/sdl3_mixer.wrap
+++ b/subprojects/sdl3_mixer.wrap
@@ -3,7 +3,8 @@ directory = SDL3_mixer-3.0.0dev
 url = https://github.com/libsdl-org/SDL_mixer
 wrapdb_version = 3.0.0-1
 patch_directory = SDL3_mixer-3.0.0dev
-revision = HEAD
+revision = daf0503cea6d9a521f585d37e785d88c2f066cd0
+# anchor sdl_mixer version to this until sdl_mixer v3 API is stable.
 
 [provide]
 sdl3_mixer = sdl3_mixer_dep


### PR DESCRIPTION
## Description
Current updates to SDL_mixer repo resulted in errors on the engine's audio system. This is pretty much expected as SDL_mixer updates most of their API and how their library works. 

For now, SDL_mixer version is anchored to the last known working version. Will rework the audio system when SDL_mixer API is a lot more stable.
