### PR TITLE
[Fix] Flipped constant for Vector2::UP and Vector2::DOWN

### DIFF
--- a/pixbench/vector2.cpp
+++ b/pixbench/vector2.cpp
@@ -150,8 +150,8 @@ double Vector2::AngleBetween(Vector2 v1, Vector2 v2) {
 }
 
 
-Vector2 Vector2::UP = Vector2(0.0, 1.0);
-Vector2 Vector2::DOWN = Vector2(0.0, -1.0);
+Vector2 Vector2::UP = Vector2(0.0, -1.0);
+Vector2 Vector2::DOWN = Vector2(0.0, 1.0);
 Vector2 Vector2::LEFT = Vector2(-1.0, -0.0);
 Vector2 Vector2::RIGHT = Vector2(1.0, 0.0);
 Vector2 Vector2::ZERO = Vector2(0.0, 0.0);


### PR DESCRIPTION
## Description
Fixing flipped constant for Vector2::UP and Vector2::DOWN

-------------
## Checklist:

1. [x] Was compilation (with `meson compile -C build/` and test run (with `build/game`) successful?
2. [x] Have you run the test with `meson test -C build`?
3. [ ] Have you added code documentation and generate the docs with doxygen?
